### PR TITLE
[RISCV] Reorganize Mips cpu feature support

### DIFF
--- a/clang/docs/ClangCommandLineReference.rst
+++ b/clang/docs/ClangCommandLineReference.rst
@@ -3787,9 +3787,11 @@ RISCV
 -----
 .. option:: -msave-restore, -mno-save-restore
 
+Enable using library calls for save and restore
+
 .. option:: -mload-store-pairs, -mno-load-store-pairs
 
-Enable using library calls for save and restore
+.. option:: -mccmov, -mno-ccmov
 
 Long double flags
 -----------------

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3308,6 +3308,8 @@ def mno_save_restore : Flag<["-"], "mno-save-restore">, Group<m_riscv_Features_G
   HelpText<"Disable using library calls for save and restore">;
 def mload_store_pairs : Flag<["-"], "mload-store-pairs">, Group<m_riscv_Features_Group>;
 def mno_load_store_pairs : Flag<["-"], "mno-load-store-pairs">, Group<m_riscv_Features_Group>;
+def mccmov : Flag<["-"], "mccmov">, Group<m_riscv_Features_Group>;
+def mno_ccmov : Flag<["-"], "mno-ccmov">, Group<m_riscv_Features_Group>;
 def mcmodel_EQ_medlow : Flag<["-"], "mcmodel=medlow">, Group<m_riscv_Features_Group>,
   Flags<[CC1Option]>, Alias<mcmodel_EQ>, AliasArgs<["small"]>,
   HelpText<"Equivalent to -mcmodel=small, compatible with RISC-V gcc.">;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2164,6 +2164,14 @@ void Clang::AddRISCVTargetArgs(const ArgList &Args,
       CmdArgs.push_back("-riscv-load-store-pairs=0");
     }
   }
+  if (Arg *A = Args.getLastArg(options::OPT_mccmov,
+                               options::OPT_mno_ccmov)) {
+    if (A->getOption().matches(options::OPT_mno_ccmov)) {
+      CmdArgs.push_back("-mllvm");
+      CmdArgs.push_back("-riscv-custom-cmov=0");
+    }
+  }
+
 }
 
 void Clang::AddSparcTargetArgs(const ArgList &Args,

--- a/llvm/lib/Target/RISCV/RISCV.td
+++ b/llvm/lib/Target/RISCV/RISCV.td
@@ -443,8 +443,8 @@ def FeatureLoadStorePairs
     : SubtargetFeature<"load-store-pairs", "UseLoadStorePairs", "true",
                        "Optimize for hardware load-store bonding">;
 
-def HasLoadStorePair : Predicate<"Subtarget->hasFeature(RISCV::Proci8500)">,
-                             AssemblerPredicate<(all_of Proci8500),
+def HasLoadStorePair : Predicate<"Subtarget->useLoadStorePairs()">,
+                             AssemblerPredicate<(any_of Proci8500, Procp8700),
                              "load and store pair instructions">;
 
 //===----------------------------------------------------------------------===//
@@ -555,8 +555,6 @@ def : ProcessorModel<"i8500", i8500Model, [Feature64Bit,
                                            FeatureStdExtF,
                                            FeatureStdExtD,
                                            FeatureStdExtC,
-                                           FeatureStdExtZba,
-                                           FeatureStdExtZbb,
                                            FeatureCustomCMov,
                                            FeatureLoadStorePairs],
                      [Proci8500]>;
@@ -567,8 +565,6 @@ def : ProcessorModel<"p8700", p8700Model, [Feature64Bit,
                                            FeatureStdExtF,
                                            FeatureStdExtD,
                                            FeatureStdExtC,
-                                           FeatureStdExtZba,
-                                           FeatureStdExtZbb,
                                            FeatureCustomCMov,
                                            FeatureLoadStorePairs],
                     [Procp8700]>;

--- a/llvm/lib/Target/RISCV/RISCVLoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVLoadStoreOptimizer.cpp
@@ -78,7 +78,6 @@ bool RISCVLoadStoreOpt::runOnMachineFunction(MachineFunction &Fn) {
   if (skipFunction(Fn.getFunction()))
     return false;
   const RISCVSubtarget &Subtarget = Fn.getSubtarget<RISCVSubtarget>();
-
   if (!Subtarget.useLoadStorePairs())
     return false;
 
@@ -89,7 +88,8 @@ bool RISCVLoadStoreOpt::runOnMachineFunction(MachineFunction &Fn) {
   AA = &getAnalysis<AAResultsWrapperPass>().getAAResults();
   ModifiedRegUnits.init(*TRI);
   UsedRegUnits.init(*TRI);
-  UseLoadStorePair = Subtarget.hasFeature(RISCV::Proci8500);
+  UseLoadStorePair = Subtarget.hasFeature(RISCV::Proci8500) ||
+                     Subtarget.hasFeature(RISCV::Procp8700);
 
   for (MachineBasicBlock &MBB : Fn) {
     LLVM_DEBUG(dbgs() << "MBB: " << MBB.getName() << "\n");

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -66,6 +66,11 @@ static cl::opt<bool> UseLoadStorePairsOpt(
     cl::desc("RISCV: Optimize for load-store bonding"),
     cl::init(true), cl::Hidden);
 
+static cl::opt<bool> UseCustomCMovInsn(
+    "riscv-custom-cmov",
+    cl::desc("RISCV: Use 'ccmov' instruction"),
+    cl::init(true), cl::Hidden);
+
 void RISCVSubtarget::anchor() {}
 
 RISCVSubtarget &
@@ -217,4 +222,8 @@ bool RISCVSubtarget::useRVVForFixedLengthVectors() const {
 
 bool RISCVSubtarget::useLoadStorePairs() const {
   return UseLoadStorePairsOpt && UseLoadStorePairs;
+}
+
+bool RISCVSubtarget::hasCustomCMov() const {
+  return UseCustomCMovInsn && HasCustomCMov;
 }

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -196,7 +196,7 @@ public:
   bool enableLinkerRelax() const { return EnableLinkerRelax; }
   bool enableRVCHintInstrs() const { return EnableRVCHintInstrs; }
   bool enableSaveRestore() const { return EnableSaveRestore; }
-  bool hasCustomCMov() const { return HasCustomCMov; }
+  bool hasCustomCMov() const;
   bool useLoadStorePairs() const;
   MVT getXLenVT() const { return XLenVT; }
   unsigned getXLen() const { return XLen; }


### PR DESCRIPTION
Remove zba and zbb.
Allow disabling ccmov with -mno-ccmov.
Make -mload-store-pairs imply l[w|d]p and s[w|d]p.
